### PR TITLE
[Bootstrapper/Loader.read] Bypass error on when `ENOENT`.

### DIFF
--- a/lib/api/folder/read.js
+++ b/lib/api/folder/read.js
@@ -72,6 +72,12 @@ exports.readDirectory = function (route) {
  * @return {Promise}
  */
 module.exports = async function (instance, component, route) {
-    let files = await exports.readDirectory(route);
-    return exports.readFiles(instance, component, route, files);
+    try {
+        let files = await exports.readDirectory(route);
+        return exports.readFiles(instance, component, route, files);
+    } catch (error) {
+        if (error.code !== 'ENOENT') {
+            throw error;
+        }
+    }
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "booljs",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Bool MVC Framework - Bootstraping Unit",
   "main": "lib/index.js",
   "license": "GPL-3.0",


### PR DESCRIPTION
Closes #12.