### PR TITLE
[BoolJSComponent] Use rest params in constructor

### DIFF
--- a/lib/api/loaders/components.js
+++ b/lib/api/loaders/components.js
@@ -3,11 +3,9 @@
 const _ = require('underscore');
 
 exports.wrapComponent = function (instance, Component) {
-    return class BoolJSComponent {
+    return class BoolJSComponent extends Component {
         constructor (...params) {
-            return new (Function.prototype.bind.apply(Component, [
-                null, instance.getComponents()
-            ].concat(params)))();
+            super(instance.getComponents(), ...params);
         }
     };
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "booljs",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Bool MVC Framework - Bootstraping Unit",
   "main": "lib/index.js",
   "license": "GPL-3.0",


### PR DESCRIPTION
It turns out it's possible to apply the [spread (...) operator with arrays in function calls](http://node.green/#ES2015-syntax-spread-------operator-with-arrays--in-function-calls) in the `super` call of a class, while taking [rest parameters](http://node.green/#ES2015-syntax-rest-parameters) from `constructor` as the base array to simplify the process of wrapping `app` in a `BoolJSComponent` letting it be extended.

Closes #22