### PR TITLE
Release v0.8.0

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "example"]
-	path = example
-	url = http://github.com/booljs/booljs-boilerplate.git

--- a/example/.jshintrc
+++ b/example/.jshintrc
@@ -1,0 +1,7 @@
+{
+    "node": true,
+    "laxcomma": true,
+    "undef": true,
+    "strict": true,
+    "unused": true
+}

--- a/example/configuration/database.json
+++ b/example/configuration/database.json
@@ -1,0 +1,18 @@
+{
+
+    "development": {
+        "host": "localhost",
+        "database": "db"
+    },
+
+    "test": {
+        "host": "localhost",
+        "database": "db_test"
+    },
+
+    "production": {
+        "host": "example.com",
+        "database": "db"
+    }
+
+}

--- a/example/configuration/server.cson
+++ b/example/configuration/server.cson
@@ -1,0 +1,5 @@
+'host': 'localhost'
+'port': 8080
+'credentials':
+    'user': 'example'
+    'password': 'samplepass'

--- a/example/controllers/dog.js
+++ b/example/controllers/dog.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = function(app){
+
+    var Dog     = app.dao.Dog
+    ,   json    = new app.views.Json();
+
+    return {
+        list: function(req, res, next){
+            var dog = new Dog();
+            json.promise(dog.list(), res, next);
+        }
+    };
+
+};

--- a/example/controllers/undesirables/kitten.js
+++ b/example/controllers/undesirables/kitten.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function (app) {
+    const { Dog } = app.dao;
+    const { promise } = new app.views.Json();
+
+    this.list = function (request, response, next) {
+        var dog = new Dog();
+        promise(dog.list(), response, next);
+    };
+};

--- a/example/dao/dog.js
+++ b/example/dao/dog.js
@@ -1,0 +1,13 @@
+'use strict';
+
+module.exports = function(app){
+
+    var dog = new app.models.Dog();
+
+    return {
+        list: function(){
+            return dog.list();
+        }
+    };
+
+};

--- a/example/index.js
+++ b/example/index.js
@@ -1,0 +1,5 @@
+'use strict';
+const Bool = require('..');
+
+// Here is where magic happens
+module.exports = new Bool('com.example.api').run();

--- a/example/models/dog.js
+++ b/example/models/dog.js
@@ -1,0 +1,48 @@
+'use strict';
+
+const dogs = [];
+
+module.exports = class DogModel {
+    constructor (app) {
+        this.Error = app.Error;
+    }
+
+    async list () {
+        return dogs;
+    }
+
+    async index (id) {
+        for (var dog in dogs) {
+            if (dogs[dog].id === id) {
+                return dog;
+            }
+        }
+        return null;
+    }
+
+    async find (id) {
+        var index = this.index(id);
+        if (index === null) {
+            throw new this.Error(
+                404, 'dog_not_found', 'The searched dog wasn\'t in the list'
+            );
+        }
+        return dogs[index];
+    }
+
+    async update (id, dog) {
+        Object.assign(this.find(id), dog);
+    }
+
+    async delete (id) {
+        var index = this.index(id);
+
+        if (index === null) {
+            throw new this.Error(
+                404, 'dog_not_found', 'The searched dog wasn\'t in the list'
+            );
+        }
+
+        dogs.splice(index, 1);
+    }
+};

--- a/example/routes/dog.js
+++ b/example/routes/dog.js
@@ -1,0 +1,16 @@
+'use strict';
+
+module.exports = function (app) {
+
+    var dog = new app.controllers.Dog();
+
+    return [
+        {
+            method: 'get',
+            url: '/dog',
+            action: dog.list,
+            cors: true
+        }
+    ];
+
+};

--- a/lib/api/configurations/index.js
+++ b/lib/api/configurations/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Error } = require('booljs.api');
+const { Error } = require('@booljs/api');
 const { readdir } = require('fs');
 const { join, parse }  = require('path');
 const Reader = require('../../readers');

--- a/lib/api/folder/read.js
+++ b/lib/api/folder/read.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Error } = require('booljs.api');
+const { Error } = require('@booljs/api');
 const { lstat, readdir } = require('fs');
 const { join, parse }  = require('path');
 const Reader = require('../../readers');

--- a/lib/api/index.js
+++ b/lib/api/index.js
@@ -12,7 +12,7 @@ const _ = require('underscore');
  */
 module.exports = class BoolJSBootstrapper {
     constructor (namespace, dependencies = []) {
-        const { Error, App } = require('booljs.api');
+        const { Error, App } = require('@booljs/api');
 
         this.Error = Error;
         this.Folder = require('./folder');
@@ -20,14 +20,12 @@ module.exports = class BoolJSBootstrapper {
         this.Configuration = require('./configurations');
         this.Loaders = require('./loaders');
 
-        this.instance = App.getInstance(namespace, dependencies.concat([
-            '@booljs/express', 'booljs.nomodel'
-        ]));
+        this.instance = App.getInstance(namespace, dependencies);
 
         this.folders = new this.Folder.List();
 
-        this.databaseDrivers = [ 'booljs.nomodel' ];
-        this.serverDrivers = [ 'booljs.express' ];
+        this.databaseDrivers = [ ];
+        this.serverDrivers = [ ];
         this.booted = false;
         this.booting = false;
         this.server = null;
@@ -124,7 +122,7 @@ module.exports = class BoolJSBootstrapper {
      * @return {BoolJSBootstrapper} The loaded application instance
      */
     setServerDrivers (...drivers) {
-        this.serverDriver = drivers;
+        this.serverDrivers = drivers;
         return this;
     }
 

--- a/lib/api/loaders/database.js
+++ b/lib/api/loaders/database.js
@@ -1,8 +1,9 @@
 'use strict';
 
-const isFunction = obj => !!(obj && obj.constructor && obj.call && obj.apply);
+const isFunction =
+    object => !!(object && object.constructor && object.call && object.apply);
 
-const { Plugins, Error } = require('booljs.api');
+const { Plugins, Error } = require('@booljs/api');
 
 /**
  * @private
@@ -13,17 +14,20 @@ const { Plugins, Error } = require('booljs.api');
  * @param {Object} connection - The connection (if any) used by the driver
  * @return {Promise}
  */
-exports.fetchModels = async function (instance, models, loader, connection) {
-    for (let model in models) {
-        if (!isFunction(models[model])) {
-            await exports.fetchModels(instance, models[model], loader, connection);
-        } else if (models[model].prototype instanceof loader.modelClass()) {
-            instance.insertComponent(model, await loader.fetchModels(
-                instance, model, models[model], connection
-            ), models);
+exports.fetchModels = async function (instance, models) {
+    const list = [];
+
+    for (let key in models) {
+        if (!isFunction(models[key])) {
+            return list
+                .concat(await exports.fetchModels(instance, models[key]));
+        } else {
+            list.push({ models, key });
         }
     }
-}
+
+    return list;
+};
 
 /**
  * @private
@@ -33,18 +37,49 @@ exports.fetchModels = async function (instance, models, loader, connection) {
  * @return {Promise}
  */
 module.exports = async function DatabaseLoader (instance, drivers) {
-    for (let driver of drivers) {
-        let loader = Plugins.get(driver);
+    const modelsList = await exports
+        .fetchModels(instance, instance.getComponents().models);
 
-        if (loader === undefined) {
-            throw new Error(0, 'E_LOADER_NOT_FOUND', 'Loader not found');
+    const loaders = await Promise.all(drivers
+        .map(async (driver, index) => {
+            const loader = Plugins.get(driver);
+
+            if (loader === undefined) {
+                throw new Error(0, 'E_LOADER_NOT_FOUND', 'Loader not found');
+            }
+
+            const settings = instance.getComponents().configuration
+                .get(index > 0
+                    ? loader.connectionSettingsStoreName
+                    : 'database');
+            const connection = await loader.openDatabase(settings);
+
+            return { loader, connection };
+        }));
+
+    for (let index in modelsList) {
+        let { models, key } = modelsList[index];
+
+        const BaseModel = models[key];
+        let Model;
+
+        for (let { loader, connection } of loaders) {
+            if (Model.prototype instanceof loader.modelClass()) {
+                Model = await loader
+                    .fetchModels(instance, key, BaseModel, connection);
+                modelsList[index] = undefined;
+            }
         }
 
-        let connection = await loader.openDatabase(instance
-            .getComponents().configuration.get('database')
-        );
+        if (modelsList[index] !== undefined) {
+            Model = class BoolJSNativeModel extends BaseModel {
+                constructor (...params) {
+                    super(instance.getComponents(), ...params);
+                }
+            };
+            modelsList[index] = undefined;
+        }
 
-        let { models } = instance.getComponents();
-        await exports.fetchModels(instance, models, loader, connection);
+        instance.insertComponent(key, Model, models);
     }
 };

--- a/lib/api/loaders/server/index.js
+++ b/lib/api/loaders/server/index.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Plugins } = require('booljs.api');
+const { Plugins } = require('@booljs/api');
 const PreRoute = require('./preroute');
 const Middleware = require('./middleware');
 const Router = require('./router');
@@ -14,14 +14,23 @@ const PostRoute = require('./postroute');
  * @return {Promise}
  */
 module.exports = async function (instance, drivers) {
-    let serverDriver = Plugins.get(drivers[0]);
+    const loadedServers = [];
 
-    let server = await serverDriver.init(instance);
-    let router = await PreRoute(instance, serverDriver, server);
+    for (let driver of drivers) {
+        let serverDriver = Plugins.get(driver);
 
-    router = await Middleware(instance, serverDriver, router);
-    router = await Router(instance, serverDriver, router);
-    server = await PostRoute(instance, serverDriver, router, server);
+        let server = await serverDriver.init(instance);
+        let router = await PreRoute(instance, serverDriver, server);
 
-    return serverDriver.boot(server);
+        router = await Middleware(instance, serverDriver, router);
+        router = await Router(instance, serverDriver, router);
+        server = await PostRoute(instance, serverDriver, router, server);
+
+        server = await serverDriver.boot(server);
+        loadedServers.push(server);
+    }
+
+    return loadedServers.length > 0
+        ? loadedServers[0]
+        : undefined;
 };

--- a/lib/api/loaders/server/middleware.js
+++ b/lib/api/loaders/server/middleware.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Plugins, Middleware } = require('booljs.api');
+const { Plugins, Middleware } = require('@booljs/api');
 
 module.exports = async function (instance, driver, router) {
     let middlewarePlugins = Plugins.list(Middleware);

--- a/lib/api/loaders/server/router.js
+++ b/lib/api/loaders/server/router.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Plugins, RouteMiddleware } = require('booljs.api');
+const { Plugins, RouteMiddleware } = require('@booljs/api');
 const _ = require('underscore');
 
 module.exports = async function (instance, loader, router) {

--- a/lib/readers/defaults/javascript.js
+++ b/lib/readers/defaults/javascript.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const { Error } = require('booljs.api');
+const { Error } = require('@booljs/api');
 
 /**
  * @private

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,40 +1,16 @@
 {
   "name": "booljs",
-  "version": "0.7.17",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "@booljs/express": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@booljs/express/-/express-0.6.6.tgz",
-      "integrity": "sha512-R3e0yAUZcg+H0QmvljiZJZUvexOGtF2ZPRIm9PpUfvkuoJ4Pgmguh4Yf8rY9ZrdBYUc+dtyUln5U5aIr7I2WLA==",
+    "@booljs/api": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@booljs/api/-/api-0.6.0.tgz",
+      "integrity": "sha512-WfuBjdfF0WqmE/3vJxa35uMgyctiQ7p+GgA496jcqeW2rPQQC+dzrcL141BRi/G86JR+YLmIo1VCvtP5KloeOw==",
       "requires": {
-        "body-parser": "^1.18.3",
-        "express": "^4.16.4"
-      }
-    },
-    "accepts": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
-      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
-      "requires": {
-        "mime-types": "~2.1.18",
-        "negotiator": "0.6.1"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
-        },
-        "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-          "requires": {
-            "mime-db": "~1.36.0"
-          }
-        }
+        "booljs.globals": "^0.1.0",
+        "object-injector": "0.0.2"
       }
     },
     "acorn": {
@@ -110,11 +86,6 @@
       "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
       "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
       "dev": true
-    },
-    "array-flatten": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
-      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "array-union": {
       "version": "1.0.2",
@@ -243,42 +214,6 @@
       "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
       "dev": true
     },
-    "body-parser": {
-      "version": "1.18.3",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
-      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
-      "requires": {
-        "bytes": "3.0.0",
-        "content-type": "~1.0.4",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "http-errors": "~1.6.3",
-        "iconv-lite": "0.4.23",
-        "on-finished": "~2.3.0",
-        "qs": "6.5.2",
-        "raw-body": "2.3.3",
-        "type-is": "~1.6.16"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
-      }
-    },
-    "booljs.api": {
-      "version": "0.5.4",
-      "resolved": "https://registry.npmjs.org/booljs.api/-/booljs.api-0.5.4.tgz",
-      "integrity": "sha512-0QFsz524Znq/GdVdqVgeF346uLBjVZFmnveNenTn5BPwkRPQdqGaO2SYlOVDlb8Pmu9PG9Jl7owDfAcvHaklHQ==",
-      "requires": {
-        "booljs.globals": "^0.1.0",
-        "object-injector": "0.0.2"
-      }
-    },
     "booljs.globals": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/booljs.globals/-/booljs.globals-0.1.0.tgz",
@@ -289,11 +224,6 @@
         "tracer": "^0.8.7",
         "underscore": "^1.8.3"
       }
-    },
-    "booljs.nomodel": {
-      "version": "0.4.4",
-      "resolved": "https://registry.npmjs.org/booljs.nomodel/-/booljs.nomodel-0.4.4.tgz",
-      "integrity": "sha512-qESgOCOvuHMHyfHQ1WQexSfn6WW8IyQfAlyB33UDicXDoQIF70HF3oyxv+j4gDvr2RM6fvqO7U/V5x0uNpKRMg=="
     },
     "brace-expansion": {
       "version": "1.1.8",
@@ -322,11 +252,6 @@
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
       "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
       "dev": true
-    },
-    "bytes": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
-      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "caller-path": {
       "version": "0.1.0",
@@ -485,9 +410,9 @@
       "dev": true
     },
     "colors": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.1.2.tgz",
-      "integrity": "sha1-FopHAXVran9RoSzgyXv6KMCE7WM="
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.3.tgz",
+      "integrity": "sha512-qTfM2pNFeMZcLvf/RbrVAzDEVttZjFhaApfx9dplNjvHSX88Ui66zBRb/4YGob/xUWxDceirgoC1lT676asfCQ=="
     },
     "combined-stream": {
       "version": "1.0.7",
@@ -527,26 +452,6 @@
       "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
       "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
       "dev": true
-    },
-    "content-disposition": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
-      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
-    },
-    "content-type": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
-      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
-    },
-    "cookie": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
-    },
-    "cookie-signature": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
-      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -621,14 +526,15 @@
       }
     },
     "dateformat": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-      "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc="
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+      "integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
     },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -669,16 +575,6 @@
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
     },
-    "depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
-    },
-    "destroy": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
-      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
-    },
     "diff": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/diff/-/diff-3.3.1.tgz",
@@ -718,16 +614,6 @@
       "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.3.tgz",
       "integrity": "sha1-CQcQG92iD6w8vjNMJ8vQaI3Jmls="
     },
-    "ee-first": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
-      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
-    },
-    "encodeurl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
-      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
-    },
     "error-ex": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
@@ -736,11 +622,6 @@
       "requires": {
         "is-arrayish": "^0.2.1"
       }
-    },
-    "escape-html": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
-      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escape-string-regexp": {
       "version": "1.0.5",
@@ -981,60 +862,6 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
       "dev": true
     },
-    "etag": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
-      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
-    },
-    "express": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.4.tgz",
-      "integrity": "sha512-j12Uuyb4FMrd/qQAm6uCHAkPtO8FDTRJZBDd5D2KOL2eLaz1yUNdUB/NOIyq0iU4q4cFarsUCrnFDPBcnksuOg==",
-      "requires": {
-        "accepts": "~1.3.5",
-        "array-flatten": "1.1.1",
-        "body-parser": "1.18.3",
-        "content-disposition": "0.5.2",
-        "content-type": "~1.0.4",
-        "cookie": "0.3.1",
-        "cookie-signature": "1.0.6",
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "finalhandler": "1.1.1",
-        "fresh": "0.5.2",
-        "merge-descriptors": "1.0.1",
-        "methods": "~1.1.2",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "path-to-regexp": "0.1.7",
-        "proxy-addr": "~2.0.4",
-        "qs": "6.5.2",
-        "range-parser": "~1.2.0",
-        "safe-buffer": "5.1.2",
-        "send": "0.16.2",
-        "serve-static": "1.13.2",
-        "setprototypeof": "1.1.0",
-        "statuses": "~1.4.0",
-        "type-is": "~1.6.16",
-        "utils-merge": "1.0.1",
-        "vary": "~1.1.2"
-      },
-      "dependencies": {
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
-    },
     "extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -1105,27 +932,6 @@
         "object-assign": "^4.0.1"
       }
     },
-    "finalhandler": {
-      "version": "1.1.1",
-      "resolved": "http://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
-      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
-      "requires": {
-        "debug": "2.6.9",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "on-finished": "~2.3.0",
-        "parseurl": "~1.3.2",
-        "statuses": "~1.4.0",
-        "unpipe": "~1.0.0"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
-    },
     "find-up": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
@@ -1175,16 +981,6 @@
           }
         }
       }
-    },
-    "forwarded": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
-      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
-    },
-    "fresh": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
-      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -1316,17 +1112,6 @@
       "integrity": "sha512-7T/BxH19zbcCTa8XkMlbK5lTo1WtgkFi3GvdWEyNuc4Vex7/9Dqbnpsf4JMydcfj9HCg4zUWFTL3Za6lapg5/w==",
       "dev": true
     },
-    "http-errors": {
-      "version": "1.6.3",
-      "resolved": "http://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
-      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
-      "requires": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.3",
-        "setprototypeof": "1.1.0",
-        "statuses": ">= 1.4.0 < 2"
-      }
-    },
     "http-signature": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
@@ -1378,7 +1163,8 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "inquirer": {
       "version": "3.3.0",
@@ -1401,11 +1187,6 @@
         "strip-ansi": "^4.0.0",
         "through": "^2.3.6"
       }
-    },
-    "ipaddr.js": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.8.0.tgz",
-      "integrity": "sha1-6qM9bd16zo9/b+DJygRA5wZzix4="
     },
     "is-arrayish": {
       "version": "0.2.1",
@@ -1652,26 +1433,6 @@
       "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
       "dev": true
     },
-    "media-typer": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
-      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
-    },
-    "merge-descriptors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
-      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
-    },
-    "methods": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
-      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
-    },
-    "mime": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
-      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
-    },
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
@@ -1705,14 +1466,12 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
-      "dev": true
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       }
@@ -1778,7 +1537,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -1791,11 +1551,6 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
-    },
-    "negotiator": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
-      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -4465,14 +4220,6 @@
         "underscore": "^1.7.0"
       }
     },
-    "on-finished": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
-      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
-      "requires": {
-        "ee-first": "1.1.1"
-      }
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -4544,11 +4291,6 @@
         "error-ex": "^1.2.0"
       }
     },
-    "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
-    },
     "path-exists": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
@@ -4581,11 +4323,6 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
       "dev": true
-    },
-    "path-to-regexp": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
-      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "path-type": {
       "version": "2.0.0",
@@ -4667,15 +4404,6 @@
       "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
       "dev": true
     },
-    "proxy-addr": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.4.tgz",
-      "integrity": "sha512-5erio2h9jp5CHGwcybmxmVqHmnCBZeewlfJ0pex+UW7Qny7OOZXTtH56TGNyBizkgiOwhJtMKrVzDTeKcySZwA==",
-      "requires": {
-        "forwarded": "~0.1.2",
-        "ipaddr.js": "1.8.0"
-      }
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
@@ -4702,37 +4430,6 @@
         "asap": "^2.0.0",
         "pop-iterate": "^1.0.1",
         "weak-map": "^1.0.5"
-      }
-    },
-    "qs": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-    },
-    "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
-    },
-    "raw-body": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
-      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
-      "requires": {
-        "bytes": "3.0.0",
-        "http-errors": "1.6.3",
-        "iconv-lite": "0.4.23",
-        "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.23",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
-          "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
-          "requires": {
-            "safer-buffer": ">= 2.1.2 < 3"
-          }
-        }
       }
     },
     "read-pkg": {
@@ -4961,56 +4658,14 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
     },
     "semver": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
-    },
-    "send": {
-      "version": "0.16.2",
-      "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
-      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
-      "requires": {
-        "debug": "2.6.9",
-        "depd": "~1.1.2",
-        "destroy": "~1.0.4",
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "etag": "~1.8.1",
-        "fresh": "0.5.2",
-        "http-errors": "~1.6.2",
-        "mime": "1.4.1",
-        "ms": "2.0.0",
-        "on-finished": "~2.3.0",
-        "range-parser": "~1.2.0",
-        "statuses": "~1.4.0"
-      },
-      "dependencies": {
-        "statuses": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
-          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
-        }
-      }
-    },
-    "serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
-      "requires": {
-        "encodeurl": "~1.0.2",
-        "escape-html": "~1.0.3",
-        "parseurl": "~1.3.2",
-        "send": "0.16.2"
-      }
-    },
-    "setprototypeof": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
-      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
     },
     "shebang-command": {
       "version": "1.2.0",
@@ -5096,11 +4751,6 @@
         "safer-buffer": "^2.0.2",
         "tweetnacl": "~0.14.0"
       }
-    },
-    "statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
       "version": "2.1.1",
@@ -5213,12 +4863,13 @@
       }
     },
     "tracer": {
-      "version": "0.8.11",
-      "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.8.11.tgz",
-      "integrity": "sha512-R1g2kqy00KSRXR6XrKYXqmOE8Tii+CkwJkHPQzGP+W5TcBUoHhNx0GNC4Vv79eU2jJyINnSSM2Zpi6nzQE6XRg==",
+      "version": "0.8.15",
+      "resolved": "https://registry.npmjs.org/tracer/-/tracer-0.8.15.tgz",
+      "integrity": "sha512-ZQzlhd6zZFIpAhACiZkxLjl65XqVwi8t8UEBVGRIHAQN6nj55ftJWiFell+WSqWCP/vEycrIbUSuiyMwul+TFw==",
       "requires": {
-        "colors": "1.1.2",
-        "dateformat": "2.0.0",
+        "colors": "1.2.3",
+        "dateformat": "3.0.3",
+        "mkdirp": "^0.5.1",
         "tinytim": "0.1.1"
       }
     },
@@ -5251,30 +4902,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "type-is": {
-      "version": "1.6.16",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
-      "integrity": "sha512-HRkVv/5qY2G6I8iab9cI7v1bOIdhm94dVjQCPFElW9W+3GeDOSHmy2EBYe4VTApuzolPcmgFTN3ftVJRKR2J9Q==",
-      "requires": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.18"
-      },
-      "dependencies": {
-        "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
-        },
-        "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-          "requires": {
-            "mime-db": "~1.36.0"
-          }
-        }
-      }
     },
     "typechecker": {
       "version": "4.4.1",
@@ -5312,11 +4939,6 @@
         }
       }
     },
-    "unpipe": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
-      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
-    },
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
@@ -5328,11 +4950,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "utils-merge": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
-      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.3.2",
@@ -5349,11 +4966,6 @@
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
       }
-    },
-    "vary": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
-      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "booljs",
-  "version": "0.7.18",
+  "version": "0.8.0-alpha.3",
   "description": "Bool MVC Framework - Bootstraping Unit",
   "main": "lib/index.js",
   "license": "GPL-3.0",
@@ -37,9 +37,7 @@
     "nyc": "^11.9.0"
   },
   "dependencies": {
-    "@booljs/express": "^0.6.6",
-    "booljs.api": "^0.5.4",
-    "booljs.nomodel": "^0.4.4",
+    "@booljs/api": "^0.6.0",
     "coffeescript": "^2.3.2",
     "cson": "^4.0.0",
     "readyness": "^0.1.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "booljs",
-  "version": "0.8.0-alpha.3",
+  "version": "0.8.0",
   "description": "Bool MVC Framework - Bootstraping Unit",
   "main": "lib/index.js",
   "license": "GPL-3.0",


### PR DESCRIPTION
BoolJS Bootstrapper v0.7.18…v0.8.0

- Migrate to `@booljs/api`
- Remove `@booljs/nomodel`. Now every modelless class should run natively the same way BoolJSComponents work.
- Deacoplate `@booljs/express`. TODO: Find out a way to test frontend
drivers.
- Fix broken assignment in `#setServerDrivers`.